### PR TITLE
Adding MutationObserverInit options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,6 +62,21 @@ setTimeout(function() {
 mutant.disconnect();
 ```
 
+By default only `childList` and `subtree` are being observed as mutation properties, but you can specify your own options as a third argument.
+
+```javascript
+var options = {
+  observers: {
+    childList: true, // listen to div's child elements additions or removals, default: true
+    subtree: false, // don't listen to div's descendants mutations, default: true
+    attributres: true // also listen to div's attributes updates, default: false
+  }
+}
+var mutant = new Mutant(div, layout, options);
+```
+
+All available mutation properties and their descriptions are listed on [MDN](https://developer.mozilla.org/en/docs/Web/API/MutationObserver#MutationObserverInit).
+
 ## License
 
   The MIT License (MIT)

--- a/lib/mutant.js
+++ b/lib/mutant.js
@@ -140,8 +140,8 @@
   function Mutant(target, callback, options) {
     this._eventHandlers = {};
 
-    var scope = options ? options.scope : null;
-    var throttleTimeout = options ? options.timeout : 0;
+    var scope = options && options.scope ? options.scope : null;
+    var throttleTimeout = options && options.timeout ? options.timeout : 0;
     var self = this;
 
     if(throttleTimeout) {
@@ -169,7 +169,20 @@
     this.observer = new MutationObserver(this._mutationCallback);
 
     // pass in the target node, as well as the observer options
-    this.observer.observe(target, { attributes: true, childList: true, characterData: true, subtree: true });
+    var observers = {
+      attributes: options && options.observers && options.observers.attributes || false,
+      childList: options && options.observers && options.observers.childList ? options.types.childList : true,
+      characterData: options && options.observers && options.observers.characterData || false,
+      subtree: options && options.observers && options.observers.subtree ? options.types.subtree : true,
+      attributeFilter: options && options.observers && options.observers.attributeFilter || []
+    };
+    if (observers.attributes && options.observers.attributeOldValue) {
+      observers.attributeOldValue = options.observers.attributeOldValue;
+    }
+    if (observers.characterData && options.observers.characterDataOldValue) {
+      observers.characterDataOldValue = options.observers.characterDataOldValue;
+    }
+    this.observer.observe(target, observers);
   }
 
   Mutant.prototype = {


### PR DESCRIPTION
This PR allows users to specify their own observers options.

The use-case is quite simple, you might not want to be called on attributes update, or on descendants updates.
I used [MDN MutationObserver](https://developer.mozilla.org/en/docs/Web/API/MutationObserver) page as a reference to implement all optional valid paths.

In order to be backward compatible with previous versions, I activated both `childList` and `subtree` by default.
