### PR TITLE
Fixing a stupid word typo for 2 of the obsersers options

### DIFF
--- a/lib/mutant.js
+++ b/lib/mutant.js
@@ -171,9 +171,9 @@
     // pass in the target node, as well as the observer options
     var observers = {
       attributes: options && options.observers && options.observers.attributes || false,
-      childList: options && options.observers && options.observers.childList ? options.types.childList : true,
+      childList: options && options.observers && options.observers.childList ? options.observers.childList : true,
       characterData: options && options.observers && options.observers.characterData || false,
-      subtree: options && options.observers && options.observers.subtree ? options.types.subtree : true,
+      subtree: options && options.observers && options.observers.subtree ? options.observers.subtree : true,
       attributeFilter: options && options.observers && options.observers.attributeFilter || []
     };
     if (observers.attributes && options.observers.attributeOldValue) {


### PR DESCRIPTION
I stupidly made a word typo for 2 of the observers options.

``` javascript
var observers = {
  attributes: options && options.observers && options.observers.attributes || false,
  childList: options && options.observers && options.observers.childList ? options.types.childList : true,
  characterData: options && options.observers && options.observers.characterData || false,
  subtree: options && options.observers && options.observers.subtree ? options.types.subtree : true,
  attributeFilter: options && options.observers && options.observers.attributeFilter || []
};
```

2 `types` were left in the middle, residue of my first local implementation, before I renamed everything to open the first PR.

It was transparent and not used because of default values.
